### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ tensorboard --logdir . --port 8887 --host 0.0.0.0
 
 # MNIST GAN trainer
 ```bash
-python experiments/train_gan.py  --config-path ./configs/train_gan.json
+python -m experiments.train_gan  --config-path ./configs/train_gan.json
 ```
 
 # MNIST conditional GAN trainer


### PR DESCRIPTION
fix the following error:
```
python experiments/train_gan.py  --config-path ./configs/train_gan.json
Traceback (most recent call last):
  File "experiments/train_gan.py", line 6, in <module>
    from models import Generator, Discriminator, MNISTGANTrainer
ModuleNotFoundError: No module named 'models'
```