### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ python -m experiments.train_gan  --config-path ./configs/train_gan.json
 
 # MNIST conditional GAN trainer
 ```bash
-python experiments/train_cgan.py  --config-path ./configs/train_cgan.json
+python -m experiments.train_cgan  --config-path ./configs/train_cgan.json
 ```
 
 


### PR DESCRIPTION
fix the following error:
```
python experiments/train_cgan.py  --config-path ./configs/train_gan.json
Traceback (most recent call last):
  File "experiments/train_gan.py", line 6, in <module>
    from models import Generator, Discriminator, MNISTGANTrainer
ModuleNotFoundError: No module named 'models'
```